### PR TITLE
use sdl2-compat to be compatible with SDL3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,24 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # - { name: 'Linux (x64)'     ,os: ubuntu-22.04              }
-          # - { name: 'Linux (arm64)'   ,os: ubuntu-22.04-arm          }
-          # - { name: 'Windows (x64)'   ,os: windows-2022              }
+          - { name: 'Linux (x64)'     ,os: ubuntu-26.04              }
+          - { name: 'Linux (arm64)'   ,os: ubuntu-26.04-arm          }
+          - { name: 'Windows (x64)'   ,os: windows-2025              }
           - { name: 'Windows (arm64)' ,os: windows-11-arm            }
-          # - { name: 'Mac (x64)'       ,os: macos-15     ,arch: x64   }
-          # - { name: 'Mac (arm64)'     ,os: macos-15     ,arch: arm64 }
+          - { name: 'Mac (x64)'       ,os: macos-26     ,arch: x64   }
+          - { name: 'Mac (arm64)'     ,os: macos-26     ,arch: arm64 }
 
     runs-on: ${{ matrix.platform.os }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: libsdl-org/setup-sdl@main
+        id: sdl
+        with:
+          install-linux-dependencies: true
+          version: 3-latest
+          version-sdl-image: 3-latest
 
       - if: ${{ startsWith(matrix.platform.os, 'macos-') }}
         run: brew update && ./scripts/install-deps-mac.sh

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ sdl
 build
 dist
 publish
+.idea
+.vscode

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.32.8-0",
+  "version": "2.32.70-0",
   "name": "@kmamal/build-sdl",
   "description": "build-sdl",
   "repository": {

--- a/scripts/download-sdl.mjs
+++ b/scripts/download-sdl.mjs
@@ -4,7 +4,7 @@ import C from './util/common.js'
 import { fetch } from './util/fetch.js'
 import * as Tar from 'tar'
 
-const url = `https://github.com/libsdl-org/SDL/archive/refs/tags/release-${C.version}.tar.gz`
+const url = `https://github.com/libsdl-org/sdl2-compat/releases/download/release-${C.version}/sdl2-compat-${C.version}.tar.gz`
 
 console.log("fetch", url)
 const response = await fetch(url)


### PR DESCRIPTION
With this branch [sdl2-compat](https://github.com/libsdl-org/sdl2-compat) will be integrated to be compatible with SDL3. I already created a release of node-sdl with this state integrated to test it: https://github.com/bmsuseluda/node-sdl/releases/tag/v0.12.0.